### PR TITLE
Use qt.labs.platform FileDialog to fix save issue

### DIFF
--- a/qml/menus/filemenu/OpenView.qml
+++ b/qml/menus/filemenu/OpenView.qml
@@ -10,7 +10,7 @@ import QtCharts 2.1
 import QtMultimedia 5.5
 import Qt.labs.settings 1.0
 import Qt.labs.folderlistmodel 2.1
-import Qt.labs.platform 1.0
+import Qt.labs.platform 1.0 as Platform
 
 import Neuronify 1.0
 import CuteVersioning 1.0
@@ -70,9 +70,9 @@ Item {
             }
         }
         
-        FileDialog {
+        Platform.FileDialog {
             id: openDialog
-            fileMode: FileDialog.OpenFile
+            fileMode: Platform.FileDialog.OpenFile
             nameFilters: ["Neuronify files (*.neuronify)"]
             onAccepted: {
                 openRequested(file)

--- a/qml/menus/filemenu/SaveView.qml
+++ b/qml/menus/filemenu/SaveView.qml
@@ -10,7 +10,7 @@ import QtCharts 2.1
 import QtMultimedia 5.5
 import Qt.labs.settings 1.0
 import Qt.labs.folderlistmodel 2.1
-import Qt.labs.platform 1.0
+import Qt.labs.platform 1.0 as Platform
 
 import Neuronify 1.0
 import CuteVersioning 1.0
@@ -107,9 +107,9 @@ Item {
             }
         }
         
-        FileDialog {
+        Platform.FileDialog {
             id: saveDialog
-            fileMode: FileDialog.SaveFile
+            fileMode: Platform.FileDialog.SaveFile
             nameFilters: ["Neuronify files (*.neuronify)"]
             defaultSuffix: ".neuronify"
             onAccepted: {


### PR DESCRIPTION
Previously, the save dialog had an "Open" button instead of a "Save"
button because the wrong FileDialog was pulled in. This made it 
impossible to save simulations. This change makes it possible to
save simulations again.